### PR TITLE
added ability for third parties to use this piece

### DIFF
--- a/third_party/mailchimp_subscribe/ext.mailchimp_subscribe.php
+++ b/third_party/mailchimp_subscribe/ext.mailchimp_subscribe.php
@@ -209,7 +209,8 @@ class Mailchimp_subscribe_ext {
     if ((strtolower($this->_ee->config->item('req_mbr_activation')) !== 'none')
       OR ( ! isset($data['username']))
       OR ( ! isset($data['email']))
-      OR ( ! isset($data['join_date'])))
+      OR ( ! isset($data['join_date']))
+	  OR ( ! empty($this->_ee->session->cache['mailchimp_subscribe']['cancel_subscription'])))
     {
       return FALSE;
     }
@@ -369,6 +370,11 @@ class Mailchimp_subscribe_ext {
     {
       $cleaned_member_fields[$key] = $data['label'];
     }
+
+	if ($this->_ee->extensions->active_hook('mailchimp_subscribe_member_fields'))
+	{
+		$cleaned_member_fields = $this->_ee->extensions->call('mailchimp_subscribe_member_fields', $cleaned_member_fields);
+	}
 
     // Collate the view variables.
     $vars = array(

--- a/third_party/mailchimp_subscribe/models/mailchimp_model.php
+++ b/third_party/mailchimp_subscribe/models/mailchimp_model.php
@@ -1117,7 +1117,14 @@ class Mailchimp_model extends CI_Model {
    * a member's existing subscriptions.
    *
    * @access  private
-   * @param   string  $member_id    The member ID.
+   * @param   string|array  $member_id    The member ID, or an array containing
+   * 										the following member data:
+   * 										- member_id
+   * 										- group_id
+   * 										- screen_name
+   * 										- email
+   * 										- custom field data for: trigger field,
+   * 										  merge variables, and interest groups
    * @param   bool    $update       Are we updating existing subscriptions?
    * @return  void
    */
@@ -1125,6 +1132,13 @@ class Mailchimp_model extends CI_Model {
     $update = FALSE
   )
   {
+	if (is_array($member_id))
+	{
+	  $member = $member_id;
+
+	  $member_id = isset($member['member_id']) ? $member['member_id'] : FALSE;
+	}
+
     // Check that we have a member ID.
     if ( ! $member_id)
     {
@@ -1132,16 +1146,19 @@ class Mailchimp_model extends CI_Model {
         (missing member ID).');
     }
 
-    // Retrieve the member.
-    $members = $this->get_members(array('member_id' => $member_id));
+	if ( ! isset($member))
+	{
+	  // Retrieve the member.
+	  $members = $this->get_members(array('member_id' => $member_id));
 
-    if (count($members) !== 1)
-    {
-      throw new MCS_Data_exception('Error retrieving member ID ' .$member_id);
-    }
+	  if (count($members) !== 1)
+	  {
+	    throw new MCS_Data_exception('Error retrieving member ID ' .$member_id);
+	  }
 
-    // Convenience.
-    $member = $members[0];
+	  // Convenience.
+	  $member = $members[0];
+	}
 
     // Is the member banned?
     if (in_array($member['group_id'], array('2', '4')))


### PR DESCRIPTION
This is an attempt to make this more extensible, so you don't have to add custom integration with every addon under the sun. With this, I can add custom integration in my addon to yours, rather than vice versa.

Summary:
added hook mailchimp_subscribe_member_fields - this effects the fields dropdown in the settings
added a flag to cancel the mailchimp subscription in member_member_register (so that I can perform it myself later) - $this->_ee->session->cache['mailchimp_subscribe']['cancel_subscription']
changed the mailchimp_model->_update_member_subscriptions to accept an array of member data instead of just the member way (so that I may provide a custom data payload instead of one you fetch based on member id)

In my addon (profile:edit), after I perform my registration:

``` php
$this->EE->load->add_package_path(PATH_THIRD.'mailchimp_subscribe/');
$this->EE->load->model('mailchimp_model');
$this->EE->mailchimp_model->subscribe_member(array(
    'member_id' => 1, //etc.
));
```
