### PR TITLE
Only loop the Zoo Visitor Member Categories if they exist. 

### DIFF
--- a/third_party/mailchimp_subscribe/models/mailchimp_model.php
+++ b/third_party/mailchimp_subscribe/models/mailchimp_model.php
@@ -1053,23 +1053,25 @@ class Mailchimp_model extends CI_Model {
         }
       }
 
-      foreach($this->_zoo_visitor_member_categories as $member_category)
-      {
-
-          $options = array();
-          foreach ($member_category['categories'] as $key => $value)
+      if (isset($this->_zoo_visitor_member_categories)) {
+          foreach($this->_zoo_visitor_member_categories as $member_category)
           {
-            $options[$value['cat_name']] = $value['cat_name'];
+
+              $options = array();
+              foreach ($member_category['categories'] as $key => $value)
+              {
+                $options[$value['cat_name']] = $value['cat_name'];
+              }
+
+              $member_fields['cat_group_id_'.$member_category['id']] = array(
+                'id'    => 'cat_group_id_'.$member_category['id'],
+                'label'   => $member_category['name'],
+                'options' => $options,
+                'type'    => 'select'
+              );
           }
 
-          $member_fields['cat_group_id_'.$member_category['id']] = array(
-            'id'    => 'cat_group_id_'.$member_category['id'],
-            'label'   => $member_category['name'],
-            'options' => $options,
-            'type'    => 'select'
-          );
-      }
-
+        }
     }
     else
     {


### PR DESCRIPTION
Prevents the following PHP errors: 

A PHP Error was encountered
Severity: Warning
Message: Invalid argument supplied for foreach()
Filename: models/mailchimp_model.php
Line Number: 1056

A PHP Error was encountered
Severity: Notice
Message: Undefined property: Addons_extensions::$_zoo_visitor_member_categories
Filename: core/Model.php
Line Number: 50
